### PR TITLE
Make text addition optional

### DIFF
--- a/src/eas_3d_pattern/parser.py
+++ b/src/eas_3d_pattern/parser.py
@@ -822,6 +822,7 @@ class AntennaPattern:
                     "val = %{z:.2f}<br>"
                     "<extra></extra>"
                 ),
+                showscale=not(remove_layout_components),
             )
         )
         fig.update_yaxes(autorange="reversed")

--- a/src/eas_3d_pattern/parser.py
+++ b/src/eas_3d_pattern/parser.py
@@ -828,8 +828,22 @@ class AntennaPattern:
         fig.update_yaxes(autorange="reversed")
         if remove_layout_components:
             fig.update_layout(
-                xaxis={"showticklabels": False},
-                yaxis={"showticklabels": False},
+                xaxis={
+                    "showticklabels": False,
+                    "showgrid": False,
+                    "zeroline": False,
+                    "showline": False,
+                },
+                yaxis={
+                    "showticklabels": False,
+                    "showgrid": False,
+                    "zeroline": False,
+                    "showline": False,
+                },
+                plot_bgcolor="rgba(0,0,0,0)",   # sin fondo gris en el área del heatmap
+                paper_bgcolor="rgba(0,0,0,0)",  # sin fondo/gris alrededor
+                margin={"t": 0, "l": 0, "r": 0, "b": 0},  # recorta al mínimo
+                height=500,
             )
         else:
             fig.update_layout(

--- a/src/eas_3d_pattern/parser.py
+++ b/src/eas_3d_pattern/parser.py
@@ -782,7 +782,7 @@ class AntennaPattern:
         return top_border
 
     def plot(
-        self, component_name: str = "P_tp_dB", show_fig: bool = True
+        self, component_name: str = "P_tp_dB", show_fig: bool = True, remove_layout_components: bool = False
     ) -> None | go.Figure:
         """Plots the radiation pattern as heatmap.
 
@@ -792,6 +792,8 @@ class AntennaPattern:
         Args:
             component_name (str, optional): Name of the component to be plotted. Defaults to 'P_tp_dB', thus power pattern.
             show_fig (bool, optional): Whether to show the figure. Defaults to True.
+            remove_layout_components (bool, optional): Whether to remove text, color bar and tick labels from plots of the antenna patterns. Default is False.
+
 
         Returns:
             None | go.Figure: None if show_fig is False else go.Figure
@@ -823,36 +825,43 @@ class AntennaPattern:
             )
         )
         fig.update_yaxes(autorange="reversed")
-        fig.update_layout(
-            title={
-                "text": os.path.basename(self.data_filepath),
-                "x": 0.5,
-                "y": 0.93,
-                "yanchor": "bottom",
-                "font": {"size": 16},
-            },
-            xaxis={
-                "title": "φ [°]",
-                "tickmode": "linear",
-                "title_standoff": 10,
-                "dtick": 30,
-                "showgrid": True,
-                "tickangle": -45,
-                "gridcolor": "rgba(0,0,0,0.2)",
-                "zeroline": False,
-            },
-            yaxis={
-                "title": "θ [°]",
-                "tickmode": "linear",
-                "title_standoff": 10,
-                "dtick": 30,
-                "showgrid": True,
-                "gridcolor": "rgba(0,0,0,0.2)",
-                "zeroline": False,
-            },
-            margin={"t": 40, "l": 60, "r": 60, "b": 60},
-            height=500,
-        )
+        if remove_layout_components:
+            fig.update_layout(
+                xaxis={"showticklabels": False},
+                yaxis={"showticklabels": False},
+            )
+        else:
+            fig.update_layout(
+                title={
+                    "text": os.path.basename(self.data_filepath),
+                    "x": 0.5,
+                    "y": 0.93,
+                    "yanchor": "bottom",
+                    "font": {"size": 16},
+                },
+                xaxis={
+                    "title": "φ [°]",
+                    "tickmode": "linear",
+                    "title_standoff": 10,
+                    "dtick": 30,
+                    "showgrid": True,
+                    "tickangle": -45,
+                    "gridcolor": "rgba(0,0,0,0.2)",
+                    "zeroline": False,
+                },
+                yaxis={
+                    "title": "θ [°]",
+                    "tickmode": "linear",
+                    "title_standoff": 10,
+                    "dtick": 30,
+                    "showgrid": True,
+                    "gridcolor": "rgba(0,0,0,0.2)",
+                    "zeroline": False,
+                },
+                margin={"t": 40, "l": 60, "r": 60, "b": 60},
+                height=500,
+            )
+
         if show_fig:
             fig.show()
             return None

--- a/src/eas_3d_pattern/util_func/report.py
+++ b/src/eas_3d_pattern/util_func/report.py
@@ -38,6 +38,7 @@ def generate_report_eas(
     input_directory: Path | str,
     output_directory: Path | str,
     plot: bool = False,
+    remove_layout_components: bool = False,
     subbands: dict[str, tuple[int, int]] = SUBBANDS_DEFAULT,
 ) -> pd.DataFrame:
     """Generates a excel report for EAS JSON files.
@@ -49,6 +50,7 @@ def generate_report_eas(
         input_directory (Path | str): The path to the directory containing the JSON files.
         output_directory (Path | str): The path to the directory where the report will be saved.
         plot (bool, optional): Whether to generate plots of the antenna patterns. Default is False.
+        remove_layout_components (bool, optional): Whether to remove text, color bar and tick labels from plots of the antenna patterns. Default is False.
         subbands (dict[str, tuple[int, int]], optional): A dictionary of subbands and their corresponding frequency ranges. Default is SUBBANDS_DEFAULT.
 
     Returns:
@@ -85,7 +87,7 @@ def generate_report_eas(
                 data_row, pattern, sectors = data
                 df_list.append(data_row)
                 if plot:
-                    _save_figure(pattern, sectors, output_directory)
+                    _save_figure(pattern, sectors, output_directory, remove_layout_components)
         df_raw = pd.concat(df_list, ignore_index=True)
 
     report_name = output_directory / "BEreport.xlsx"
@@ -177,6 +179,7 @@ def _save_figure(
     pattern: AntennaPattern,
     sector_definitions: SectorDefinition,
     output_directory: Path,
+    remove_layout_components: bool = False,
 ) -> None:
     """Saves the plot of the given AntennaPattern and SectorDefinition to a PNG file.
 
@@ -184,11 +187,11 @@ def _save_figure(
         pattern (AntennaPattern): The AntennaPattern to plot.
         sector_definitions (SectorDefinition): The SectorDefinition to use for plotting.
         output_directory (Path): The directory to save the plot to.
-
+        remove_layout_components (bool, optional): Whether to remove text, color bar and tick labels from plots of the antenna patterns. Default is False.
     Returns:
         None
     """
-    fig = pattern.plot(show_fig=False)
+    fig = pattern.plot(show_fig=False,remove_layout_components=remove_layout_components)
     if fig is None:
         return
     for k in sector_definitions.sectors:


### PR DESCRIPTION
Some context:

Pepe has modified Georg's eas-3d-pattern code on git hub to add an extra option useful for Christian and his automatic datasheet generator, and would like Waldemar's team to review it before making it available to everyone. We agreed that:

Pepe will add Kostas and Mattia to the repo and to call for a session with Lucas and Mattia for review.
