### PR TITLE
chore: add CODEOWNERS for automatic review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @tiamilani


### PR DESCRIPTION
Adding CODEOWNERS to manage automatic reviewers for PR.
This is going to take effect only once branch protection is going to be active with "Require review from Code Owners".
For now using myself as default reviewer, @lnribeiro please let me know if you would like to be included.

Mattia